### PR TITLE
single quote syntax error 

### DIFF
--- a/transigner/pre.py
+++ b/transigner/pre.py
@@ -155,9 +155,9 @@ def write_psw_data(tsize, per_tx_cov, per_base_cov, psw, cum_psw, tnames, out_di
     out_lns_cpsw = []
     for i in range(tsize):
         tname = tnames[i]
-        out_lns_pbase.append(f'{tname},{np.array2string(per_base_cov[i], separator=' ')}')
-        out_lns_psw.append(f'{tname},{np.array2string(psw[i], separator=' ')}')
-        out_lns_cpsw.append(f'{tname},{np.array2string(cum_psw[i], separator=' ')}')
+        out_lns_pbase.append(f"{tname},{np.array2string(per_base_cov[i], separator=' ')}")
+        out_lns_psw.append(f"{tname},{np.array2string(psw[i], separator=' ')}")
+        out_lns_cpsw.append(f"{tname},{np.array2string(cum_psw[i], separator=' ')}")
     fn = os.path.join(out_dir, 'per_base_cov.csv')
     join_and_write(out_lns_pbase, fn)
     fn = os.path.join(out_dir, 'psw.csv')


### PR DESCRIPTION
version 1.1.3, compiled with **fopenmp** and installed within a conda environment using python3.9 was throwing this syntax error when running `transigner --version`. 

```
Traceback (most recent call last):
  File "/opt/conda/bin/transigner", line 5, in <module>
    from transigner.run_transigner import main
  File "/opt/conda/lib/python3.9/site-packages/transigner/run_transigner.py", line 4, in <module>
    from transigner import align, pre, em
  File "/opt/conda/lib/python3.9/site-packages/transigner/pre.py", line 158
    out_lns_pbase.append(f'{tname},{np.array2string(per_base_cov[i], separator=' ')}')
                                                                                     ^
SyntaxError: f-string: unmatched '('
```

The single quote syntax error first occurred on the line below. Python interprets the single quote inside separator=' ' as the end of the string. 
`out_lns_pbase.append(f'{tname},{np.array2string(per_base_cov[i], separator=' ')}')` 

Single quotes ' ' in the f-string where changed to double quotes " " and changes pushed.
`out_lns_pbase.append(f"{tname},{np.array2string(per_base_cov[i], separator=' ')}")` 


transigner was reinstalled with changes and confirmed to work as intended. 
