### PR TITLE
added modified easy.sh script, slight additions to README to describe easy.sh 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,19 @@ Either clang or gcc must be available for compiling from source. transigner uses
 
 transigner consists of three modules: align, prefilter, and em. easy.sh runs these modules at once:
 ```
-easy.sh reads.fastq transcripts.fa out_dir // will execute align, pre, and em modules
+easy.sh -a aligner_threads -e EM_threads -d data_type -m mode <reads.fastq> <transcripts.fa> <out_dir>   
+// will execute align, pre, and em modules
 ```
-There are static variables in this script that requires your attention:
+
+The script takes four options which require values to be passed to them. 
 ```
-aln_p # number of threads to use for minimap2 alignment
-em_p # number of threas to use for EM iterations; only possible when openmp is available
-data_type # input data type [ont_drna, ont_cdna, pacbio]
-mode # transigner modes [default, psw, spiked]
+-a number of threads to use for minimap2 alignment (integer)
+-e number of threads to use for EM iterations; only possible when openmp is available, if unavailable set this as '1' (integer)
+-d input data type [ont_drna, ont_cdna, pacbio] 
+-m transigner modes [default, psw, spiked] 
 ```
+The three positional arguments must be provided in correct order after the options: 1) reads.fastq 2) transcripts.fa 3) output_directory 
+
 We are still actively investigating the optimal parameter combinations for different data types, and the spiked mode is also under active development.
 
 We provide a small set of query reads and target transcripts under `test_data/` directory. You'll get exactly 1 EM iteration. 
@@ -74,6 +78,8 @@ Usage: transigner [MODULE] args [options]
           deactivate the drop feature that removes low scoring compatibility relationships
       -df, --drop-fac
           drop factor used to calculate the threshold for the drop
+      -dtype 
+          input data type [ont_drna, ont_cdna, pacbio]
 ```
 
 ## Output

--- a/easy.sh
+++ b/easy.sh
@@ -1,33 +1,119 @@
 #!/usr/bin/env bash
 
-reads=$1
-transcripts=$2
-out_dir=$3
+# Set flag defaults
+a_flag=0
+e_flag=0
+d_flag=0
+m_flag=0
 
-aln_p=24 # number of threads to use for minimap2 alignment
-em_p=4 # number of threads to use for EM iterations
-data_type="ont_drna" # input data type
-mode="default"
+##########################################################
+#                        HELP                            #
+##########################################################
+function Help() 
+{   
+# Show help 
+    echo "transigner start-to-end in one command - use correct order of positional arguments.
+    Usage: 
+        easy.sh -a aligner_threads -e em_threads -d data_type -m mode <reads> <transcripts> <outdir> 
+        easy.sh -h 
+        easy.sh -v  
+    
+    Arguments:
+        reads           input reads
+        transcripts     reference transcripts
+        outdir          output directory
+        -a              minimap2 alignment threads
+        -e              EM iterations threads (requires openmp during compilation)
+        -d              data type [ont_drna, ont_cdna, pacbio]
+        -m              transigner mode [default, psw, spiked]
+    
+    Options: 
+        -h              Show help  
+        -v              transigner version
+        " 
+        exit 1;
+}
 
+#########################################################
+
+# Unset variables in case they are host assigned and thus inherited 
+#unset -v reads transcripts out_dir aln_p em_p data_type mode
+
+# Process options 
+while getopts ":a:e:d:m:hv" option; do
+    case $option in 
+        a) a_flag=1
+            aln_p="${OPTARG}"
+            ;;
+        e) e_flag=1
+            em_p="${OPTARG}"
+            ;;
+        d) d_flag=1
+            data_type="${OPTARG}"
+            ;;
+        m) m_flag=1
+            mode="${OPTARG}"
+            ;;
+        h) Help
+            ;;
+        v) transigner --version >&2
+            exit 1
+            ;;
+        \?) echo "Please enter in valid arguments, see -h for help" >&2 
+            exit 1
+            ;;
+        :) echo "Option -${OPTARG} requires an argument" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Need shift statement to handle positional args $1 $2 $3  
+shift "$((OPTIND-1))"
+
+#aln_p=24 # number of threads to use for minimap2 alignment
+#em_p=4 # number of threads to use for EM iterations
+#data_type="ont_drna" # input data type
+#mode="default"
+
+# Check if all mandatory options were provided
+if [ $a_flag -eq 0 ] || [ $e_flag -eq 0 ] || [ $d_flag -eq 0 ] || [ $m_flag -eq 0 ] ; then
+  echo "Error: All options -a, -e, -d and -m are mandatory."
+  Help
+fi
+
+# Check if positional arguments are provided
+if [ $# -lt 3 ]; then
+  echo "Error: Missing positional arguments."
+fi
+
+# Now set variables for positional arguments 
+reads="$1"
+transcripts="$2"
+out_dir="$3"
+
+# Safety options
 set -x
 
-transigner align -q $reads -t $transcripts -d $out_dir \
-   -o "aligned.bam" -p $aln_p
-if [ $mode == "default" ]; then
-    transigner pre -i "${out_dir}/aligned.bam" -d $out_dir 
-    transigner em -s "${out_dir}/scores.csv" -d $out_dir \
+transigner align -q "$reads" -t "$transcripts" -d "$out_dir" \
+   -o "aligned.bam" -p "$aln_p"
+if [ "$mode" == "default" ]; then
+    transigner pre -i "${out_dir}/aligned.bam" -d "$out_dir" 
+    transigner em -s "${out_dir}/scores.csv" -d "$out_dir" \
         -u "${out_dir}/unmapped.txt" -m "${out_dir}/tmap.csv" \
-        -dtype $data_type -p $em_p
-elif [ $mode == "psw"]; then
-    transigner pre -i "${out_dir}/aligned.bam" -d $out_dir --use-psw
-    transigner em -s "${out_dir}/scores.csv" -d $out_dir \
+        -dtype "$data_type" -p "$em_p"
+elif [ "$mode" == "psw" ]; then
+    transigner pre -i "${out_dir}/aligned.bam" -d "$out_dir" --use-psw
+    transigner em -s "${out_dir}/scores.csv" -d "$out_dir" \
         -u "${out_dir}/unmapped.txt" -m "${out_dir}/tmap.csv" \
-        -dtype $data_type -p $em_p --no-drop
-elif [ $mode == "spiked" ]; then
-    transigner pre -i "${out_dir}/aligned.bam" -d $out_dir --spiked
-    transigner em -s "${out_dir}/scores.csv" -d $out_dir \
+        -dtype "$data_type" -p "$em_p" --no-drop
+elif [ "$mode" == "spiked" ]; then
+    transigner pre -i "${out_dir}/aligned.bam" -d "$out_dir" --spiked
+    transigner em -s "${out_dir}/scores.csv" -d "$out_dir" \
         -u "${out_dir}/unmapped.txt" -m "${out_dir}/tmap.csv" \
-        -dtype $data_type -p $em_p
+        -dtype "$data_type" -p "$em_p"
 else
     echo "unrecognized mode"
 fi
+
+# END easy.sh 


### PR DESCRIPTION
I am looking to run this software in a nextflow workflow using transigner inside a container --- although the individual **align,pre,em** modules are perfectly suited to the container, the layout of `easy.sh` could use some slight additions. 

The current `easy.sh` script has hard coded variables for:

- aln_p # number of threads to use for minimap2 alignment
- em_p # number of threas to use for EM iterations; only possible when openmp is available
- data_type # input data type [ont_drna, ont_cdna, pacbio]
- mode # transigner modes [default, psw, spiked]

If the software is being run using a container, the current `easy.sh` will not allow the user to change the variables to suit their requirements, and reformatting the container for each use case is impractical. 

To get around this, the `easy.sh` script has been modified to allow the user to pass arguments to the script which change the variables.
The modified `easy.sh` was run inside a Docker container using the provided test data to confirm that it functions as intended.  

```bash
docker run -v /home/my_dir/out:/out \
    number25/transigner:1.1.3 easy.sh \ 
    -a 2 -e 1 -d ont_drna -m default \ 
    ./test_data/test.fq.gz \ 
    ./test_data/hg38_mrna+lncrna.fa.gz \
    /out
```
All outputs as produced :) 

The instructions referring to `easy.sh` in the README were updated to reflect the modified `easy.sh` script

Additionally, the mandatory `-dtype` parameter was added to the README as it wasn't listed previously. 

What do you think? 